### PR TITLE
Fix buildability in SBCL

### DIFF
--- a/src/indices/indexed-class.lisp
+++ b/src/indices/indexed-class.lisp
@@ -286,7 +286,7 @@ also index subclasses of the class to which the slot belongs, default is T")
 			       :name 'destroyed-p
 			       :initform nil
 			       :class class
-			       #+(or cmu sbcl)
+			       #+cmu
 			       ,@'(:readers nil :writers nil)
 			       :initfunction #'(lambda () nil))))
     (cons destroyed-p-slot normal-slots)))


### PR DESCRIPTION
From Christophe Rhodes: Effective slot definitions don't (in the MOP)
have readers or writers; those are attached to direct slots.  SBCL is
now enforcing this, and this change is backwards-compatible because
the default for the slots was NIL in any case.
