### PR TITLE
SB-THREAD:DESTROY-THREAD deprecated in sbcl 1.2.15

### DIFF
--- a/src/utils/acl-mp-compat.lisp
+++ b/src/utils/acl-mp-compat.lisp
@@ -60,7 +60,7 @@
   #+cmu (mp:make-process function :name name))
 
 (defun destroy-process (process)
-  #+sbcl (sb-thread:destroy-thread process)
+  #+sbcl (sb-thread:terminate-thread process)
   #+openmcl (ccl:process-kill process)
   #+cmu (mp:destroy-process process))
 


### PR DESCRIPTION
Change SB-THREAD:DESTROY-THREAD (deprecated in sbcl 1.2.15) to SB-THREAD:TERMINATE-THREAD in acl-mp-compat.lisp.