### PR TITLE
Accumulate characters in sax:characters

### DIFF
--- a/src/xml-impex/xml-import.lisp
+++ b/src/xml-impex/xml-import.lisp
@@ -67,7 +67,10 @@
   (with-slots (class elmdef slots children) instance
     (let ((slot (xml-class-body-slot class)))
       (when slot
-        (setf (gethash slot slots) (slot-parse-value slot characters))))))
+        (setf (gethash slot slots)
+              (concatenate 'string
+                           (gethash slot slots)
+                           (slot-parse-value slot characters)))))))
 
 (defmethod importer-add-element ((handler xml-class-importer)
                                (node xml-node) element value)

--- a/src/xml-impex/xml-import.lisp
+++ b/src/xml-impex/xml-import.lisp
@@ -1,6 +1,6 @@
 (in-package :bknr.impex)
 
-(defclass xml-class-importer ()
+(defclass xml-class-importer (sax:default-handler)
   ((dtd        :initarg :dtd :initform nil :reader importer-dtd)
    (class-hash :initarg :class-hash :accessor importer-class-hash)
    (root-elt   :initform nil :accessor importer-root-elt)


### PR DESCRIPTION
When an xml element contains encoded entities like &amp, sax:characters
is called multiple times, so we need to concatenate the result.

slot-parse-value is called once per chunk of strings, and does not get
the whole string at once. Maybe slot-parse-value should be called
somewhere at sax:end-element or importer-finalize.