### PR TITLE
todo list: make-object was removed in favour of make-instance

### DIFF
--- a/src/data/TODO
+++ b/src/data/TODO
@@ -6,13 +6,6 @@ x rollforward until, restore until, usw...
 
 - import-image anschauen, nicht mehr failsafe
 
-- Revise and document make-object und initargs behaviour.  Upon
-  restore, initargs for transient slots are ignored now, but this is
-  not completely thought out.  It would better not to log initargs for
-  transient slots in the first place.
-
 - tx-persistent-change-class does not maintain indices
 
 - XXXX broken initialize-persistent-instance (?)
-
-- Get rid of MAKE-OBJECT, use MAKE-INSTANCE instead


### PR DESCRIPTION
Hello,

I guess there is no need to "Revise and document make-object und initargs behaviour" either.

Regards.

fixes #12