### PR TITLE
Replace sb-kernel:: with sb-sys: on a symbol

### DIFF
--- a/src/data/txn.lisp
+++ b/src/data/txn.lisp
@@ -498,7 +498,7 @@ to the log file in an atomic group"))
   #+cmu
   (unix:unix-fsync (kernel::fd-stream-fd stream))
   #+sbcl
-  (sb-posix:fsync (sb-kernel::fd-stream-fd stream)))
+  (sb-posix:fsync (sb-sys:fd-stream-fd stream)))
 
 (defvar *disable-sync* nil)
 


### PR DESCRIPTION
Use of :: with internal sbcl packages is a code smell.
If the symbol is exported from some internal package,
use that instead.