### PR TITLE
arnesi:ensure-list -> alexandria:ensure-list

### DIFF
--- a/src/data/encoding-test.lisp
+++ b/src/data/encoding-test.lisp
@@ -35,7 +35,7 @@
       (decode in))))
 
 (defmacro test-encoding (name value)
-  (let ((options (arnesi:ensure-list name)))
+  (let ((options (alexandria:ensure-list name)))
     (destructuring-bind (name &key skip) options
       `(5am:test ,name
                   ,(if skip


### PR DESCRIPTION
As  `arnesi` system is not in a list of `depends-on`,  I assume that `ensure-list` needs to be referenced to similar function in `alexandria` package.